### PR TITLE
Runtime detection of Pico-W

### DIFF
--- a/.github/workflows/pico-build.yml
+++ b/.github/workflows/pico-build.yml
@@ -14,10 +14,6 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        board: [pico, pico_w]
-
     steps:
     - uses: actions/checkout@v3
       with:
@@ -38,29 +34,28 @@ jobs:
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
-      run: PICO_BOARD=${{ matrix.board }} cmake -E make_directory ${{github.workspace}}/build_${{ matrix.board }}
+      run: cmake -E make_directory ${{github.workspace}}/build
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
-      working-directory: ${{github.workspace}}/build_${{ matrix.board }}
+      working-directory: ${{github.workspace}}/build
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: PICO_BOARD=${{ matrix.board }} PICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk cmake $GITHUB_WORKSPACE
+      run: PICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk cmake $GITHUB_WORKSPACE
 
     - uses: ammaraskar/gcc-problem-matcher@master
 
     - name: Build
-      working-directory: ${{github.workspace}}/build_${{ matrix.board }}
+      working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: PICO_BOARD=${{ matrix.board }} PICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk cmake --build . --config $BUILD_TYPE --parallel 4
+      run: PICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk cmake --build . --config $BUILD_TYPE --parallel 4
 
     - name: Save artifact
       uses: actions/upload-artifact@v3
       with:
-        name: rp2040-dmxsun_${{ matrix.board }}
-        path: ${{github.workspace}}/build_${{ matrix.board }}/*.uf2
-
+        name: rp2040-dmxsun
+        path: ${{github.workspace}}/build/*.uf2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.13)
 
+## Define the board as pico_w. This includes everything in the firmware
+## but the actual board detection is done at runtime
+## https://forums.raspberrypi.com/viewtopic.php?t=336775
+set(ENV{PICO_BOARD} "pico_w")
+
 ## pico_sdk_import.cmake is copied from
 ## https://github.com/raspberrypi/pico-sdk/blob/master/external/pico_sdk_import.cmake
 include(${CMAKE_CURRENT_LIST_DIR}/pico_sdk_import.cmake)
@@ -75,26 +80,17 @@ include(${CMAKE_CURRENT_LIST_DIR}/lib/jsoncpp/interfaceLibForPicoSDK.cmake)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (PICO_CYW43_SUPPORTED) # set by PICO_BOARD=pico_w
-    set(PICO_W_SOURCES
-        ${CMAKE_CURRENT_LIST_DIR}/src/eth_cyw43.cpp
-    )
-else()
-    set(PICO_W_SOURCES
-    )
-endif()
-
 ## Add our own C/C++ files here
 ## Sorted alphabetically
 add_executable(${CMAKE_PROJECT_NAME}
     ${TINYUSB_LIBNETWORKING_SOURCES}
-    ${PICO_W_SOURCES}
     ${CMAKE_CURRENT_LIST_DIR}/src/boardconfig.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/crc_X25.c
     ${CMAKE_CURRENT_LIST_DIR}/src/dhcpdata.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/dhcpserver.c
     ${CMAKE_CURRENT_LIST_DIR}/src/dmxbuffer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/edp.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/eth_cyw43.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/localdmx.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/log.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/main.cpp
@@ -112,7 +108,6 @@ add_executable(${CMAKE_PROJECT_NAME}
     ${CMAKE_CURRENT_LIST_DIR}/src/webserver.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/wireless.cpp
 )
-
 
 
 ## Add our rp2040-PIO programs here
@@ -174,30 +169,29 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
 ## lwip_init() is being called twice
 include(${CMAKE_CURRENT_LIST_DIR}/lib/pico_cyw43_arch_nolwip/CMakeLists.txt)
 
-if (PICO_CYW43_SUPPORTED) # set by PICO_BOARD=pico_w
-    ## equals pico_cyw43_arch_none:
-    target_compile_definitions(pico_cyw43_arch_nolwip INTERFACE
-        ## Compiles, links and inits fine (with the unmodified library):
-        #CYW43_LWIP=0
-        #PICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 # none still uses threadsafe_background to make gpio use easy
+## equals pico_cyw43_arch_none:
+target_compile_definitions(pico_cyw43_arch_nolwip INTERFACE
+    ## Compiles, links and inits fine (with the unmodified library):
+    #CYW43_LWIP=0
+    #PICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 # none still uses threadsafe_background to make gpio use easy
 
-        ## Compiles fine, fails to link due to unfdefined references (with the unmodified library):
-        #CYW43_LWIP=0
-        #PICO_CYW43_ARCH_POLL=1
+    ## Compiles fine, fails to link due to unfdefined references (with the unmodified library):
+    #CYW43_LWIP=0
+    #PICO_CYW43_ARCH_POLL=1
 
-        ## Compiles fine, links fine but fails to init (with the unmodified library):
-        #CYW43_LWIP=1
-        #PICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 # none still uses threadsafe_background to make gpio use easy
+    ## Compiles fine, links fine but fails to init (with the unmodified library):
+    #CYW43_LWIP=1
+    #PICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 # none still uses threadsafe_background to make gpio use easy
 
-        ## Compiles fine, links fine but fails to init (with the unmodified library):
-        CYW43_LWIP=1
-        PICO_CYW43_ARCH_POLL=1
-    )
-endif()
+    ## Compiles fine, links fine but fails to init (with the unmodified library):
+    CYW43_LWIP=1
+    PICO_CYW43_ARCH_POLL=1
+)
 
 ## Pull in all pico-sdk + non-pico-sdk libraries
 ## Sorted alphabetically
 target_link_libraries(${CMAKE_PROJECT_NAME}
+    hardware_adc
     hardware_dma
     hardware_flash
     hardware_i2c
@@ -208,6 +202,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
     libb64
     lwipallapps
     lwipcore
+    pico_cyw43_arch_nolwip
     pico_multicore
     pico_stdlib
     pico_unique_id
@@ -218,12 +213,6 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
     tinyusb_board
     tinyusb_device
 )
-
-if (PICO_CYW43_SUPPORTED) # set by PICO_BOARD=pico_w
-    target_link_libraries(${CMAKE_PROJECT_NAME}
-        pico_cyw43_arch_nolwip ## Our custom one in the lib folder
-    )
-endif()
 
 ## Create map/bin/hex/uf2 file etc.
 pico_add_extra_outputs(${CMAKE_PROJECT_NAME})

--- a/src/boardconfig.cpp
+++ b/src/boardconfig.cpp
@@ -20,6 +20,7 @@ ConfigSource BoardConfig::configSource = ConfigSource::Fallback;
 uint8_t BoardConfig::shortId;
 char BoardConfig::boardSerialString[25];
 char BoardConfig::boardHostnameString[12];
+bool BoardConfig::boardIsPicoW;
 
 
 void BoardConfig::init() {

--- a/src/boardconfig.h
+++ b/src/boardconfig.h
@@ -251,6 +251,8 @@ class BoardConfig {
     static char boardSerialString[25];
     static char boardHostnameString[12];
 
+    static bool boardIsPicoW;
+
   private:
     uint8_t rawData[5][2048];  // raw content of the memories (0-3: 4 IO boards, 4: baseboard, 2048 byte each)
 };

--- a/src/eth_cyw43.h
+++ b/src/eth_cyw43.h
@@ -9,12 +9,4 @@ class Eth_cyw43 {
   private:
 };
 
-// If we are NOT on pico_w, we have PIN_LED and we need to define dummies
-// since eth_cyw43.cpp won't be compiled
-#ifdef PIN_LED
-    // Dummies so we don't have to do the #ifdef-dance on every call to those
-    void Eth_cyw43::init() {};
-    void Eth_cyw43::cyclicTask() {};
-#endif
-
 #endif // ETH_CYW43_H

--- a/src/picotool_binary_information.h
+++ b/src/picotool_binary_information.h
@@ -24,12 +24,10 @@ bi_decl(bi_4pins_with_names(PIN_IO01_0, "IO board 01, pin 0", PIN_IO01_1, "IO bo
 bi_decl(bi_4pins_with_names(PIN_IO10_0, "IO board 10, pin 0", PIN_IO10_1, "IO board 10, pin 1", PIN_IO10_2, "IO board 10, pin 2", PIN_IO10_3, "IO board 10, pin 3"));
 bi_decl(bi_4pins_with_names(PIN_IO11_0, "IO board 11, pin 0", PIN_IO11_1, "IO board 11, pin 1", PIN_IO11_2, "IO board 11, pin 2", PIN_IO11_3, "IO board 11, pin 3"));
 
-#ifdef PIN_LED
-bi_decl(bi_1pin_with_name(PIN_LED, "On-board status LED"));
-#endif
+bi_decl(bi_1pin_with_name(PIN_LED_PICO, "On-board status LED (Pico only)"));
 
 bi_decl(bi_1pin_with_name(PIN_LEDS, "Off-board status LEDs (WS2812-based)"));
 
-bi_decl(bi_1pin_with_name(PIN_TRIGGER, "Helper pin for DMX driver-enable to trigger oscilloscope"));
+bi_decl(bi_1pin_with_name(PIN_TRIGGER, "Optional helper pin for DMX driver-enable to trigger oscilloscope"));
 
 #endif // PICOTOOL_BINARY_INFORMATION_H

--- a/src/pins.h
+++ b/src/pins.h
@@ -42,10 +42,10 @@
 #define PIN_IO11_3     21
 
 // Pico's on-board, single-color status LED
-// Not available on the Pico-W
-#ifdef PICO_DEFAULT_LED_PIN
-#define PIN_LED        PICO_DEFAULT_LED_PIN // = 25 on the pico
-#endif
+// If a regular "Pico" is detected at runtime => Port 25
+// If a Pico-W is detected at runtime => GPIO 0 of the cyw43
+#define PIN_LED_PICO   25
+#define PIN_LED_PICOW  CYW43_WL_GPIO_LED_PIN
 
 // WS2812-based status LEDs
 #define PIN_LEDS       22

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -419,6 +419,7 @@ u16_t WebServer::ssi_handler(const char* ssi_tag_name, char *pcInsert, int iInse
         output["debug"]["structSize"]["EthDestParams"] = sizeof(EthDestParams);
 
         output["boardName"] = boardConfig.activeConfig->boardName;
+        output["boardIsPicoW"] = BoardConfig::boardIsPicoW;
         output["configSource"] = boardConfig.configSource;
         output["configSourceString"] = std::string(magic_enum::enum_name<ConfigSource>(boardConfig.configSource));
         output["version"] = VERSION;


### PR DESCRIPTION
Goal is to have one firmware binary that runs on the classic Pico as well as on the Pico-W. However, we cannot just initialize the cyw43 and hope it to fail on the Pico since it will just get stuck.
Therefore, do a runtime detection as proposed in https://forums.raspberrypi.com/viewtopic.php?t=336775 and act depending on result.
Also, revert 4f3e763 and let the GH action only build one firmware binary.