### PR TITLE
Typo: use loadConfig.bind() in Load configuration button

### DIFF
--- a/wwwsrc/src/BoardStatus.js
+++ b/wwwsrc/src/BoardStatus.js
@@ -501,7 +501,7 @@ class BoardStatus extends React.Component{
                                     <button type="button" className="btn btn-outline-secondary"
                                       data-bs-toggle="tooltip" data-bs-placement="bottom"
                                       title="Load configuration from this io board"
-                                      onClick={this.saveConfig.bind(this, slot)}>
+                                      onClick={this.loadConfig.bind(this, slot)}>
                                         <Icon.JournalArrowUp width={32} height={32} pointerEvents="none"/>
                                     </button>
                                     &nbsp;


### PR DESCRIPTION
In wwwsrc/src/BoardStatus.js the button "Load configuration from this io board" should use
`onClick={this.loadConfig.bind(this, slot)}>`
